### PR TITLE
DeviceConfigurationADMX_Import_FromJSON_Assign.ps1

### DIFF
--- a/Intune-PowerShell/DeviceConfiguration/DeviceConfigurationADMX_Import_FromJSON.ps1
+++ b/Intune-PowerShell/DeviceConfiguration/DeviceConfigurationADMX_Import_FromJSON.ps1
@@ -292,6 +292,74 @@ NAME: Add-DeviceConfigurationPolicy
 	
 	
 	####################################################
+
+	Function Add-GroupPolicyConfigurationsAssignment(){
+
+	<#
+	.SYNOPSIS
+	This function is used to assign a group to a group policy configuration using the Graph API REST interface
+	.DESCRIPTION
+	The function connects to the Graph API Interface and adds a device compliance policy assignment
+	.EXAMPLE
+	Add-GroupPolicyConfigurationsAssignment -GroupPolicyId $GroupPolicyConfigurationID -TargetGroupId $TargetGroupId
+	Adds a group policy assignment in Intune
+	.NOTES
+	NAME: Add-GroupPolicyConfigurationsAssignment
+	#>
+
+[cmdletbinding()]
+
+param
+(
+    [Parameter(Mandatory = $false)]
+	[string]$GroupPolicyId,
+    [Parameter(Mandatory = $true)]
+	[string]$TargetGroupId
+)
+
+$graphApiVersion = "beta"
+$Resource = "deviceManagement/groupPolicyConfigurations/$GroupPolicyId/assign"
+    
+    try {
+
+$JSON = @"
+
+    {
+        "assignments": [
+        {
+            "target": {
+            "@odata.type": "#microsoft.graph.groupAssignmentTarget",
+            "groupId": "$TargetGroupId"
+            }
+        }
+        ]
+    }
+    
+"@
+
+    $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)"
+    Invoke-RestMethod -Uri $uri -ContentType "application/json" -Headers $authToken -Method Post -Body $JSON
+
+    }
+    
+    catch {
+
+    $ex = $_.Exception
+    $errorResponse = $ex.Response.GetResponseStream()
+    $reader = New-Object System.IO.StreamReader($errorResponse)
+    $reader.BaseStream.Position = 0
+    $reader.DiscardBufferedData()
+    $responseBody = $reader.ReadToEnd();
+    Write-Host "Response content:`n$responseBody" -f Red
+    Write-Error "Request to $Uri failed with HTTP Status $($ex.Response.StatusCode) $($ex.Response.StatusDescription)"
+    write-host
+    break
+
+    }
+
+}
+
+####################################################
 	
 	Function Test-JSON()
 	{
@@ -439,3 +507,5 @@ if (!(Test-Path "$ImportPath"))
 }
 
 Get-ChildItem "$ImportPath" | Where-Object { $_.PSIsContainer -eq $True } | ForEach-Object { import-ADMX $_.FullName }
+
+Add-GroupPolicyConfigurationsAssignment -GroupPolicyId $GroupPolicyConfigurationID


### PR DESCRIPTION
The addition of Add-GroupPolicyConfigurationsAssignment. Allowing the ability to assign a single target group to the newly imported policy.
This function uses $GroupPolicyConfigurationID generated when the policy is initially imported. Plus the '$targetgroupid' which needs to be specified (mandatory parameter)